### PR TITLE
Expand weekly breakdown content

### DIFF
--- a/index.html
+++ b/index.html
@@ -371,52 +371,72 @@ summary { font-weight: bold; }
     <details>
       <summary><strong>Week 1:</strong> Safety Review &amp; Design Brief</summary>
       <p><strong>Content:</strong> Introduce project requirements and review safety rules.</p>
+      <p><strong>Theory:</strong> WHS legislation overview and how to interpret the design brief.</p>
       <p><strong>Practical:</strong> Begin concept sketches.</p>
+      <p><strong>Resources:</strong> Design brief and safety guidelines – Google Classroom Week&nbsp;1.</p>
     </details>
     <details>
       <summary><strong>Week 2:</strong> Working Drawings &amp; Cutting List</summary>
       <p><strong>Content:</strong> Produce detailed drawings and compile a cutting list.</p>
+      <p><strong>Theory:</strong> Drawing conventions, measuring tools and accuracy.</p>
       <p><strong>Practical:</strong> Select timber and mark out components.</p>
+      <p><strong>Resources:</strong> Drawing templates and cutting list sheet – Google Classroom Week&nbsp;2.</p>
     </details>
     <details>
       <summary><strong>Week 3:</strong> Prepare Legs and Rails</summary>
       <p><strong>Content:</strong> Shape legs and rails; practise mortise and tenon joints.</p>
+      <p><strong>Theory:</strong> Timber properties and joint options for small furniture.</p>
       <p><strong>Practical:</strong> Cut and plane pieces to size.</p>
+      <p><strong>Resources:</strong> Mortise and tenon guide – Google Classroom Week&nbsp;3.</p>
     </details>
     <details>
       <summary><strong>Week 4:</strong> Assemble Table Frame</summary>
       <p><strong>Content:</strong> Dry fit legs and rails and check for squareness.</p>
+      <p><strong>Theory:</strong> Clamping techniques and adhesive selection.</p>
       <p><strong>Practical:</strong> Glue and clamp the frame.</p>
+      <p><strong>Resources:</strong> Adhesives data sheet – Google Classroom Week&nbsp;4.</p>
     </details>
     <details>
       <summary><strong>Week 5:</strong> Drawer or Shelf Construction</summary>
       <p><strong>Content:</strong> Construct drawer or shelf components and fit runners.</p>
+      <p><strong>Theory:</strong> Drawer joinery and hardware options.</p>
       <p><strong>Practical:</strong> Continue assembly and adjust the fit.</p>
+      <p><strong>Resources:</strong> Drawer plans and hardware guide – Google Classroom Week&nbsp;5.</p>
     </details>
     <details>
       <summary><strong>Week 6:</strong> Fit Top &amp; Hardware</summary>
       <p><strong>Content:</strong> Attach the top and install any hardware.</p>
+      <p><strong>Theory:</strong> Fasteners, hinges and surface preparation for finishing.</p>
       <p><strong>Practical:</strong> Sand the assembled table.</p>
+      <p><strong>Resources:</strong> Hardware specifications – Google Classroom Week&nbsp;6.</p>
     </details>
     <details>
       <summary><strong>Week 7:</strong> Surface Preparation</summary>
       <p><strong>Content:</strong> Discuss finishes and surface defects.</p>
+      <p><strong>Theory:</strong> Sanding grits and defect repair methods.</p>
       <p><strong>Practical:</strong> Fill imperfections and sand smooth.</p>
+      <p><strong>Resources:</strong> Sanding technique video – Google Classroom Week&nbsp;7.</p>
     </details>
     <details>
       <summary><strong>Week 8:</strong> Apply Finish</summary>
       <p><strong>Content:</strong> Apply an oil or clear coat.</p>
+      <p><strong>Theory:</strong> Types of finishes and safe application.</p>
       <p><strong>Practical:</strong> Coat surfaces and allow to dry.</p>
+      <p><strong>Resources:</strong> Finishing guide and safety sheet – Google Classroom Week&nbsp;8.</p>
     </details>
     <details>
       <summary><strong>Week 9:</strong> Evaluation &amp; Folio Completion</summary>
       <p><strong>Content:</strong> Reflect on the project process.</p>
+      <p><strong>Theory:</strong> Evaluation criteria for finished projects.</p>
       <p><strong>Practical:</strong> Photograph the table and finalise the folio.</p>
+      <p><strong>Resources:</strong> Folio checklist – Google Classroom Week&nbsp;9.</p>
     </details>
     <details>
       <summary><strong>Week 10:</strong> Hand In &amp; Review</summary>
       <p><strong>Content:</strong> Submit the project and review learning.</p>
+      <p><strong>Theory:</strong> Project management reflection and self-assessment.</p>
       <p><strong>Practical:</strong> Present finished work and assist with clean up.</p>
+      <p><strong>Resources:</strong> Submission checklist – Google Classroom Week&nbsp;10.</p>
     </details>
     <div class="resource-links">
       <ul>


### PR DESCRIPTION
## Summary
- add theory and resources notes for each week in the bedside table project page

## Testing
- `tidy -q -e index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d57301608326b2cb929274f78025