### PR TITLE
Fix repeated pages on desk tidy site

### DIFF
--- a/desk-tidy-main (4)/desk-tidy-main/loadSections.js
+++ b/desk-tidy-main (4)/desk-tidy-main/loadSections.js
@@ -26,23 +26,24 @@ function loadSections() {
 }
 
 async function loadWeeks() {
-  async function fetchWeekSequential(section, count) {
-    const container = document.getElementById(section + '-weeks');
-    if (!container) return;
-    for (let i = 1; i <= count; i++) {
-      const resp = await fetch(`sections/${section}/week${i}.html`);
-      const html = await resp.text();
-      const div = document.createElement('div');
-      div.innerHTML = html;
-      container.appendChild(div);
-    }
-  }
-
-  const promises = [];
   for (const [section, count] of Object.entries(weekCounts)) {
-    promises.push(fetchWeekSequential(section, count));
+    const container = document.getElementById(section + '-weeks');
+    if (!container) continue;
+
+    const list = document.createElement('ul');
+
+    for (let i = 1; i <= count; i++) {
+      const li = document.createElement('li');
+      const link = document.createElement('a');
+      link.href = `sections/${section}/week${i}.html`;
+      link.textContent = `Week ${i}`;
+      link.target = '_blank';
+      li.appendChild(link);
+      list.appendChild(li);
+    }
+
+    container.appendChild(list);
   }
-  return Promise.all(promises);
 }
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- stop injecting full week pages for desk tidy project
- generate week links instead

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688046b98ff883269575f83e1e186c19