### PR TITLE
Open week details by default

### DIFF
--- a/Main theory Content/week1.html
+++ b/Main theory Content/week1.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
       <summary><strong>Week 1:</strong> Introduction, OHS, and Risk Management</summary>
       <article>
         <h4>Overview</h4>

--- a/Main theory Content/week10.html
+++ b/Main theory Content/week10.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
         <summary><strong>Week 10:</strong> Advanced Design Features and Orthogonal Drawings</summary>
         <article>
           <h4>Theory Content</h4>

--- a/Main theory Content/week11.html
+++ b/Main theory Content/week11.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
         <summary><strong>Week 11:</strong> Assembly, Gluing Techniques, and Costing</summary>
         <article>
           <h4>Theory Content</h4>

--- a/Main theory Content/week12.html
+++ b/Main theory Content/week12.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
         <summary><strong>Week 12:</strong> Assembly, Gluing, Sequencing, and Time Planning</summary>
         <article>
           <h4>Theory Content</h4>

--- a/Main theory Content/week13.html
+++ b/Main theory Content/week13.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
         <summary><strong>Week 13:</strong> Finishing Techniques and Timber Logging</summary>
         <article>
           <h4>Theory Content</h4>

--- a/Main theory Content/week14.html
+++ b/Main theory Content/week14.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
         <summary><strong>Week 14:</strong> Advanced Finishing Techniques and Industry Visit Preparation</summary>
         <article>
           <h4>Theory Content</h4>

--- a/Main theory Content/week15.html
+++ b/Main theory Content/week15.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
         <summary><strong>Week 15:</strong> Safe Handling of Chemicals and Material Safety Data Sheets (MSDS)</summary>
         <article>
           <h4>Theory Content</h4>

--- a/Main theory Content/week16.html
+++ b/Main theory Content/week16.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
           <summary><strong>Week 16:</strong> Polishing Techniques, Sustainability, and Environmental Impact</summary>
           <article>
             <h4>Theory Content</h4>

--- a/Main theory Content/week17.html
+++ b/Main theory Content/week17.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
           <summary><strong>Week 17:</strong> Portfolio Presentation and Project Evaluation</summary>
           <article>
             <h4>Theory Content</h4>

--- a/Main theory Content/week18.html
+++ b/Main theory Content/week18.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
           <summary><strong>Week 18:</strong> Class Test and Review of Key Concepts</summary>
           <article>
             <h4>Theory Content</h4>

--- a/Main theory Content/week19.html
+++ b/Main theory Content/week19.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
   <summary><strong>Week 19:</strong> Catch-Up, Final Adjustments, and Workshop Maintenance</summary>
   <article>
     <h4>Theory Content</h4>

--- a/Main theory Content/week2.html
+++ b/Main theory Content/week2.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
   <summary><strong>Week 2:</strong> Design, Sketches, Measuring, and Mark-Out</summary>
   <article>
     <h4>Overview</h4>

--- a/Main theory Content/week20.html
+++ b/Main theory Content/week20.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
   <summary><strong>Week 20:</strong> Final Submission and Workshop Reflection</summary>
   <article>
     <h4>Theory Content</h4>

--- a/Main theory Content/week3.html
+++ b/Main theory Content/week3.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
       <summary><strong>Week 3:</strong> Dressing and Preparing Timber - DAR and FEWTEL</summary>
       <article>
         <h4>Theory Content</h4>

--- a/Main theory Content/week4.html
+++ b/Main theory Content/week4.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
       <summary><strong>Week 4:</strong> On-Guard Mortiser and Joinery Techniques</summary>
       <article>
         <h4>Theory Content</h4>

--- a/Main theory Content/week5.html
+++ b/Main theory Content/week5.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
       <summary><strong>Week 5:</strong> Mortise and Tenon Joints &amp; Bandsaw Safety</summary>
       <article>
         <h4>Theory Content</h4>

--- a/Main theory Content/week6.html
+++ b/Main theory Content/week6.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
         <summary><strong>Week 6:</strong> Bandsaw SOP and Refinement of Mortise and Tenon Joints</summary>
         <article>
           <h4>Theory Content</h4>

--- a/Main theory Content/week7.html
+++ b/Main theory Content/week7.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
         <summary><strong>Week 7:</strong> Bandsaw SOP and Refinement of Mortise and Tenon Joints</summary>
         <article>
           <h4>Theory Content</h4>

--- a/Main theory Content/week8.html
+++ b/Main theory Content/week8.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
         <summary><strong>Week 8:</strong> Dry Clamping, Work Method Statements (WMS), and SOPs</summary>
         <article>
           <h4>Theory Content</h4>

--- a/Main theory Content/week9.html
+++ b/Main theory Content/week9.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
         <summary><strong>Week 9:</strong> Adding Design Features and Orthogonal Drawings</summary>
         <article>
           <h4>Theory Content</h4>

--- a/advanced theory content/week10.html
+++ b/advanced theory content/week10.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 19 &amp; 20:</strong> Final Adjustments, Submission, and Reflective Practice</summary>
     <form class="quiz" id="adv-week19-form">
       <ol>

--- a/advanced theory content/week2.html
+++ b/advanced theory content/week2.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 3 &amp; 4:</strong> Timber Dressing, Mortising, and Joinery</summary>
     <form class="quiz" id="adv-week3-form">
       <ol>

--- a/advanced theory content/week3.html
+++ b/advanced theory content/week3.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 5 &amp; 6:</strong> Bandsaw Operation, Mortise and Tenon Refinement</summary>
     <form class="quiz" id="adv-week5-form">
       <ol>

--- a/advanced theory content/week4.html
+++ b/advanced theory content/week4.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 7 &amp; 8:</strong> Timber Thicknessing, Orthogonal Drawings, Dry Clamping, and WMS</summary>
     <form class="quiz" id="adv-week7-form">
       <ol>

--- a/advanced theory content/week5.html
+++ b/advanced theory content/week5.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 9 &amp; 10:</strong> Design Features, Advanced Orthogonal Drawings, and CAD</summary>
     <form class="quiz" id="adv-week9-form">
       <ol>

--- a/advanced theory content/week6.html
+++ b/advanced theory content/week6.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 11 &amp; 12:</strong> Assembly, Gluing Techniques, Sequencing, and Time Planning</summary>
     <form class="quiz" id="adv-week11-form">
       <ol>

--- a/advanced theory content/week7.html
+++ b/advanced theory content/week7.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 13 &amp; 14:</strong> Finishing Techniques, Timber Sustainability, and Industry Preparation</summary>
     <form class="quiz" id="adv-week13-form">
       <ol>

--- a/advanced theory content/week8.html
+++ b/advanced theory content/week8.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 15 &amp; 16:</strong> Chemical Safety, Polishing, Sustainability, and Environmental Responsibility</summary>
     <form class="quiz" id="adv-week15-form">
       <ol>

--- a/advanced theory content/week9.html
+++ b/advanced theory content/week9.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 17 &amp; 18:</strong> Portfolio Presentation, Project Evaluation, and Comprehensive Review</summary>
     <form class="quiz" id="adv-week17-form">
       <ol>

--- a/desk-tidy-main (4)/desk-tidy-main/sections/advanced-activities/week10.html
+++ b/desk-tidy-main (4)/desk-tidy-main/sections/advanced-activities/week10.html
@@ -1,5 +1,5 @@
 
-    <details>
+    <details open>
       <summary><b>Week 10: Advanced Content</b></summary>
       <article>
         <p>The project wraps up with cost calculations and reflection on skills gained.</p>  

--- a/desk-tidy-main (4)/desk-tidy-main/sections/advanced-activities/week2.html
+++ b/desk-tidy-main (4)/desk-tidy-main/sections/advanced-activities/week2.html
@@ -1,5 +1,5 @@
 
-    <details>
+    <details open>
       <summary><b>Week 2: Advanced Content</b></summary>
       <article>
         <p>This week covers advanced layout tools like marking gauges and sliding

--- a/desk-tidy-main (4)/desk-tidy-main/sections/advanced-activities/week3.html
+++ b/desk-tidy-main (4)/desk-tidy-main/sections/advanced-activities/week3.html
@@ -1,5 +1,5 @@
 
-    <details>
+    <details open>
       <summary><b>Week 3: Advanced Content</b></summary>
       <article>
         <p>We explore joinery options such as housing joints and rebates to create stronger connections.</p>  

--- a/desk-tidy-main (4)/desk-tidy-main/sections/advanced-activities/week4.html
+++ b/desk-tidy-main (4)/desk-tidy-main/sections/advanced-activities/week4.html
@@ -1,5 +1,5 @@
 
-    <details>
+    <details open>
       <summary><b>Week 4: Advanced Content</b></summary>
       <article>
         <p>Students refine their designs using simple prototypes and 3D visualisation tools.</p>  

--- a/desk-tidy-main (4)/desk-tidy-main/sections/advanced-activities/week5.html
+++ b/desk-tidy-main (4)/desk-tidy-main/sections/advanced-activities/week5.html
@@ -1,5 +1,5 @@
 
-    <details>
+    <details open>
       <summary><b>Week 5: Advanced Content</b></summary>
       <article>
         <p>This week we look at advanced measuring and marking techniques to

--- a/desk-tidy-main (4)/desk-tidy-main/sections/advanced-activities/week6.html
+++ b/desk-tidy-main (4)/desk-tidy-main/sections/advanced-activities/week6.html
@@ -1,5 +1,5 @@
 
-    <details>
+    <details open>
       <summary><b>Week 6: Advanced Content</b></summary>
       <article>
         <p>Focus on sanding and surface preparation including grain filling for open-pore timbers.</p>  

--- a/desk-tidy-main (4)/desk-tidy-main/sections/advanced-activities/week7.html
+++ b/desk-tidy-main (4)/desk-tidy-main/sections/advanced-activities/week7.html
@@ -1,5 +1,5 @@
 
-    <details>
+    <details open>
       <summary><b>Week 7: Advanced Content</b></summary>
       <article>
         <p>Different finishing products are compared, including oils, varnishes and waxes.</p>  

--- a/desk-tidy-main (4)/desk-tidy-main/sections/advanced-activities/week8.html
+++ b/desk-tidy-main (4)/desk-tidy-main/sections/advanced-activities/week8.html
@@ -1,5 +1,5 @@
 
-    <details>
+    <details open>
       <summary><b>Week 8: Advanced Content</b></summary>
       <article>
         <p>Investigate hardware options such as hinges or magnets to add features to the project.</p>  

--- a/desk-tidy-main (4)/desk-tidy-main/sections/advanced-activities/week9.html
+++ b/desk-tidy-main (4)/desk-tidy-main/sections/advanced-activities/week9.html
@@ -1,5 +1,5 @@
 
-    <details>
+    <details open>
       <summary><b>Week 9: Advanced Content</b></summary>
       <article>
         <p>This week focuses on user testing and evaluating feedback to refine the design.</p>  

--- a/desk-tidy-main (4)/desk-tidy-main/sections/main-theory/week10.html
+++ b/desk-tidy-main (4)/desk-tidy-main/sections/main-theory/week10.html
@@ -1,5 +1,5 @@
 
-    <details>
+    <details open>
       <summary><b>Week 10: Finishing Touches and Presentation</b></summary>
       <article>
         <p>In the final week, give your desk tidy a smooth finish and prepare

--- a/desk-tidy-main (4)/desk-tidy-main/sections/main-theory/week2.html
+++ b/desk-tidy-main (4)/desk-tidy-main/sections/main-theory/week2.html
@@ -1,5 +1,5 @@
 
-  <details>
+  <details open>
     <summary><b>Week 2: Design Brief and the Design Process</b></summary>
     <article>
       <h4>Design Brief</h4>

--- a/desk-tidy-main (4)/desk-tidy-main/sections/main-theory/week3.html
+++ b/desk-tidy-main (4)/desk-tidy-main/sections/main-theory/week3.html
@@ -1,5 +1,5 @@
 
-    <details>
+    <details open>
       <summary><b>Week 3: Sketching and Developing Design Ideas</b></summary>
       <article>
         <p>Now that you have a clear idea of the problem and have done some research, it's time to come up with design ideas for your desk tidy.</p>  

--- a/desk-tidy-main (4)/desk-tidy-main/sections/main-theory/week4.html
+++ b/desk-tidy-main (4)/desk-tidy-main/sections/main-theory/week4.html
@@ -1,5 +1,5 @@
 
-  <details>
+  <details open>
     <summary><b>Week 4: Planning and Materials</b></summary>
     <article>
       <p>With your design complete, this week focuses on planning the build and selecting suitable timber. Pine is often used because it is a softwood that cuts easily and is inexpensive. Check what sizes are available and adjust your design if needed. Make a simple plan that lists each piece and the order you will cut, drill and join them.</p>  

--- a/desk-tidy-main (4)/desk-tidy-main/sections/main-theory/week5.html
+++ b/desk-tidy-main (4)/desk-tidy-main/sections/main-theory/week5.html
@@ -1,5 +1,5 @@
 
-      <details>
+      <details open>
         <summary><b>Week 5: Measuring and Marking Out</b></summary>
         <article>
           <p>Now we get hands-on: before any cutting, we need to accurately measure and mark our wood. Precision here means parts that fit well.</p>  

--- a/desk-tidy-main (4)/desk-tidy-main/sections/main-theory/week6.html
+++ b/desk-tidy-main (4)/desk-tidy-main/sections/main-theory/week6.html
@@ -1,5 +1,5 @@
 
-      <details>
+      <details open>
       <summary><b>Week 6: Cutting and Assembly</b></summary>
         <article>
           <p>This week we cut our marked pieces and begin joining them to build the desk tidy body.</p>  

--- a/desk-tidy-main (4)/desk-tidy-main/sections/main-theory/week7.html
+++ b/desk-tidy-main (4)/desk-tidy-main/sections/main-theory/week7.html
@@ -1,5 +1,5 @@
 
-      <details>
+      <details open>
         <summary><b>Week 7: Attaching Hardware</b></summary>
         <article>
           <p>With the desk tidy assembled, this week focuses on attaching small hardware like handles or hooks. Correct placement and screw technique keep your project sturdy.</p>  

--- a/desk-tidy-main (4)/desk-tidy-main/sections/main-theory/week8.html
+++ b/desk-tidy-main (4)/desk-tidy-main/sections/main-theory/week8.html
@@ -1,5 +1,5 @@
 
-    <details>
+    <details open>
       <summary><b>Week 8: Decorative Touches and Finishing</b></summary>
       <article>
         <p>This week focuses on adding colour and protective coatings to give your desk tidy a finished look.</p>  

--- a/desk-tidy-main (4)/desk-tidy-main/sections/main-theory/week9.html
+++ b/desk-tidy-main (4)/desk-tidy-main/sections/main-theory/week9.html
@@ -1,5 +1,5 @@
 
-    <details>
+    <details open>
   <summary><b>Week 9: Finishing and Evaluating</b></summary>
   <article>
     <h4>Final Finishes</h4>

--- a/desk-tidy-main (4)/desk-tidy-main/sections/support-activities/week1.html
+++ b/desk-tidy-main (4)/desk-tidy-main/sections/support-activities/week1.html
@@ -1,5 +1,5 @@
 
-  <details>
+  <details open>
     <summary><b>Week 1: Workshop Safety - Support Level</b></summary>
     <article>
       <p>In the workshop, safety is paramount. Always wear protective gear such as safety glasses and keep the workspace clean to prevent accidents. Remember to tie back long hair and avoid running.</p>

--- a/desk-tidy-main (4)/desk-tidy-main/sections/support-activities/week10.html
+++ b/desk-tidy-main (4)/desk-tidy-main/sections/support-activities/week10.html
@@ -1,5 +1,5 @@
 
-  <details>
+  <details open>
     <summary><b>Week 10: Presentation - Support Level</b></summary>
     <article>
       <p>Presentation involves explaining your design and process. Use clear speech, point out key features, and answer audience questions. Ensure the workspace is tidy afterward.</p>

--- a/desk-tidy-main (4)/desk-tidy-main/sections/support-activities/week2.html
+++ b/desk-tidy-main (4)/desk-tidy-main/sections/support-activities/week2.html
@@ -1,5 +1,5 @@
 
-  <details>
+  <details open>
     <summary><b>Week 2: Design Process - Support Level</b></summary>
     <article>
       <p>The design process starts with identifying a problem. You create a design brief, research existing solutions, sketch ideas, and plan materials before building.</p>

--- a/desk-tidy-main (4)/desk-tidy-main/sections/support-activities/week3.html
+++ b/desk-tidy-main (4)/desk-tidy-main/sections/support-activities/week3.html
@@ -1,5 +1,5 @@
 
-  <details>
+  <details open>
     <summary><b>Week 3: Sketching - Support Level</b></summary>
     <article>
       <p>Sketching helps communicate ideas. Use light, thin lines and label key parts. A sketch does not need perfect measurements but should clearly show shapes and dimensions.</p>

--- a/desk-tidy-main (4)/desk-tidy-main/sections/support-activities/week4.html
+++ b/desk-tidy-main (4)/desk-tidy-main/sections/support-activities/week4.html
@@ -1,5 +1,5 @@
 
-  <details>
+  <details open>
     <summary><b>Week 4: Materials and Planning - Support Level</b></summary>
     <article>
       <p>Materials must be chosen based on the project requirements. A cutting list helps you list the pieces and sizes you need. Planning prevents material waste.</p>

--- a/desk-tidy-main (4)/desk-tidy-main/sections/support-activities/week5.html
+++ b/desk-tidy-main (4)/desk-tidy-main/sections/support-activities/week5.html
@@ -1,5 +1,5 @@
 
-  <details>
+  <details open>
     <summary><b>Week 5: Measuring and Marking - Support Level</b></summary>
     <article>
       <p>Accurate measuring and marking ensure that pieces fit together correctly. Use millimetres for precision and always verify measurements before cutting.</p>

--- a/desk-tidy-main (4)/desk-tidy-main/sections/support-activities/week6.html
+++ b/desk-tidy-main (4)/desk-tidy-main/sections/support-activities/week6.html
@@ -1,5 +1,5 @@
 
-  <details>
+  <details open>
     <summary><b>Week 6: Cutting and Assembly - Support Level</b></summary>
     <article>
       <p>When cutting, secure materials with clamps and use smooth, controlled strokes. During assembly, apply glue to joining surfaces and use clamps or screws to hold pieces together.</p>

--- a/desk-tidy-main (4)/desk-tidy-main/sections/support-activities/week7.html
+++ b/desk-tidy-main (4)/desk-tidy-main/sections/support-activities/week7.html
@@ -1,5 +1,5 @@
 
-  <details>
+  <details open>
     <summary><b>Week 7: Attaching Hardware - Support Level</b></summary>
     <article>
       <p>Attaching hardware like hinges and handles requires drilling pilot holes to prevent splitting. Countersink screws so the heads sit flush with the surface.</p>

--- a/desk-tidy-main (4)/desk-tidy-main/sections/support-activities/week8.html
+++ b/desk-tidy-main (4)/desk-tidy-main/sections/support-activities/week8.html
@@ -1,5 +1,5 @@
 
-  <details>
+  <details open>
     <summary><b>Week 8: Finishing - Support Level</b></summary>
     <article>
       <p>Finishing adds protection and appearance. Sand surfaces smooth, apply primer or sealer before painting, and use thin, even coats of finish. Remove dust between coats.</p>

--- a/desk-tidy-main (4)/desk-tidy-main/sections/support-activities/week9.html
+++ b/desk-tidy-main (4)/desk-tidy-main/sections/support-activities/week9.html
@@ -1,5 +1,5 @@
 
-  <details>
+  <details open>
     <summary><b>Week 9: Evaluating - Support Level</b></summary>
     <article>
       <p>Evaluate your product by checking functionality, appearance, and adherence to design criteria. Test stability and note improvements for future projects.</p>

--- a/sections/advanced-activities/week10.html
+++ b/sections/advanced-activities/week10.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 19 &amp; 20:</strong> Final Adjustments, Submission, and Reflective Practice</summary>
     <form class="quiz" id="adv-week19-form">
       <ol>

--- a/sections/advanced-activities/week2.html
+++ b/sections/advanced-activities/week2.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 3 &amp; 4:</strong> Timber Dressing, Mortising, and Joinery</summary>
     <form class="quiz" id="adv-week3-form">
       <ol>

--- a/sections/advanced-activities/week3.html
+++ b/sections/advanced-activities/week3.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 5 &amp; 6:</strong> Bandsaw Operation, Mortise and Tenon Refinement</summary>
     <form class="quiz" id="adv-week5-form">
       <ol>

--- a/sections/advanced-activities/week4.html
+++ b/sections/advanced-activities/week4.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 7 &amp; 8:</strong> Timber Thicknessing, Orthogonal Drawings, Dry Clamping, and WMS</summary>
     <form class="quiz" id="adv-week7-form">
       <ol>

--- a/sections/advanced-activities/week5.html
+++ b/sections/advanced-activities/week5.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 9 &amp; 10:</strong> Design Features, Advanced Orthogonal Drawings, and CAD</summary>
     <form class="quiz" id="adv-week9-form">
       <ol>

--- a/sections/advanced-activities/week6.html
+++ b/sections/advanced-activities/week6.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 11 &amp; 12:</strong> Assembly, Gluing Techniques, Sequencing, and Time Planning</summary>
     <form class="quiz" id="adv-week11-form">
       <ol>

--- a/sections/advanced-activities/week7.html
+++ b/sections/advanced-activities/week7.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 13 &amp; 14:</strong> Finishing Techniques, Timber Sustainability, and Industry Preparation</summary>
     <form class="quiz" id="adv-week13-form">
       <ol>

--- a/sections/advanced-activities/week8.html
+++ b/sections/advanced-activities/week8.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 15 &amp; 16:</strong> Chemical Safety, Polishing, Sustainability, and Environmental Responsibility</summary>
     <form class="quiz" id="adv-week15-form">
       <ol>

--- a/sections/advanced-activities/week9.html
+++ b/sections/advanced-activities/week9.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 17 &amp; 18:</strong> Portfolio Presentation, Project Evaluation, and Comprehensive Review</summary>
     <form class="quiz" id="adv-week17-form">
       <ol>

--- a/sections/main-theory/week1.html
+++ b/sections/main-theory/week1.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
       <summary><strong>Week 1:</strong> Introduction, OHS, and Risk Management</summary>
       <article>
         <h4>Overview</h4>

--- a/sections/main-theory/week10.html
+++ b/sections/main-theory/week10.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
         <summary><strong>Week 10:</strong> Advanced Design Features and Orthogonal Drawings</summary>
         <article>
           <h4>Theory Content</h4>

--- a/sections/main-theory/week11.html
+++ b/sections/main-theory/week11.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
         <summary><strong>Week 11:</strong> Assembly, Gluing Techniques, and Costing</summary>
         <article>
           <h4>Theory Content</h4>

--- a/sections/main-theory/week12.html
+++ b/sections/main-theory/week12.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
         <summary><strong>Week 12:</strong> Assembly, Gluing, Sequencing, and Time Planning</summary>
         <article>
           <h4>Theory Content</h4>

--- a/sections/main-theory/week13.html
+++ b/sections/main-theory/week13.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
         <summary><strong>Week 13:</strong> Finishing Techniques and Timber Logging</summary>
         <article>
           <h4>Theory Content</h4>

--- a/sections/main-theory/week14.html
+++ b/sections/main-theory/week14.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
         <summary><strong>Week 14:</strong> Advanced Finishing Techniques and Industry Visit Preparation</summary>
         <article>
           <h4>Theory Content</h4>

--- a/sections/main-theory/week15.html
+++ b/sections/main-theory/week15.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
         <summary><strong>Week 15:</strong> Safe Handling of Chemicals and Material Safety Data Sheets (MSDS)</summary>
         <article>
           <h4>Theory Content</h4>

--- a/sections/main-theory/week16.html
+++ b/sections/main-theory/week16.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
           <summary><strong>Week 16:</strong> Polishing Techniques, Sustainability, and Environmental Impact</summary>
           <article>
             <h4>Theory Content</h4>

--- a/sections/main-theory/week17.html
+++ b/sections/main-theory/week17.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
           <summary><strong>Week 17:</strong> Portfolio Presentation and Project Evaluation</summary>
           <article>
             <h4>Theory Content</h4>

--- a/sections/main-theory/week18.html
+++ b/sections/main-theory/week18.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
           <summary><strong>Week 18:</strong> Class Test and Review of Key Concepts</summary>
           <article>
             <h4>Theory Content</h4>

--- a/sections/main-theory/week19.html
+++ b/sections/main-theory/week19.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
   <summary><strong>Week 19:</strong> Catch-Up, Final Adjustments, and Workshop Maintenance</summary>
   <article>
     <h4>Theory Content</h4>

--- a/sections/main-theory/week2.html
+++ b/sections/main-theory/week2.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
   <summary><strong>Week 2:</strong> Design, Sketches, Measuring, and Mark-Out</summary>
   <article>
     <h4>Overview</h4>

--- a/sections/main-theory/week20.html
+++ b/sections/main-theory/week20.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
   <summary><strong>Week 20:</strong> Final Submission and Workshop Reflection</summary>
   <article>
     <h4>Theory Content</h4>

--- a/sections/main-theory/week3.html
+++ b/sections/main-theory/week3.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
       <summary><strong>Week 3:</strong> Dressing and Preparing Timber - DAR and FEWTEL</summary>
       <article>
         <h4>Theory Content</h4>

--- a/sections/main-theory/week4.html
+++ b/sections/main-theory/week4.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
       <summary><strong>Week 4:</strong> On-Guard Mortiser and Joinery Techniques</summary>
       <article>
         <h4>Theory Content</h4>

--- a/sections/main-theory/week5.html
+++ b/sections/main-theory/week5.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
       <summary><strong>Week 5:</strong> Mortise and Tenon Joints &amp; Bandsaw Safety</summary>
       <article>
         <h4>Theory Content</h4>

--- a/sections/main-theory/week6.html
+++ b/sections/main-theory/week6.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
         <summary><strong>Week 6:</strong> Bandsaw SOP and Refinement of Mortise and Tenon Joints</summary>
         <article>
           <h4>Theory Content</h4>

--- a/sections/main-theory/week7.html
+++ b/sections/main-theory/week7.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
         <summary><strong>Week 7:</strong> Bandsaw SOP and Refinement of Mortise and Tenon Joints</summary>
         <article>
           <h4>Theory Content</h4>

--- a/sections/main-theory/week8.html
+++ b/sections/main-theory/week8.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
         <summary><strong>Week 8:</strong> Dry Clamping, Work Method Statements (WMS), and SOPs</summary>
         <article>
           <h4>Theory Content</h4>

--- a/sections/main-theory/week9.html
+++ b/sections/main-theory/week9.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
         <summary><strong>Week 9:</strong> Adding Design Features and Orthogonal Drawings</summary>
         <article>
           <h4>Theory Content</h4>

--- a/sections/support-activities/week1.html
+++ b/sections/support-activities/week1.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 1 &amp; 2:</strong> Introduction to Workshop Safety, Marking, and Measuring</summary>
     <article>
       <h4>Week 1: Workshop Safety and Basic Procedures</h4>

--- a/sections/support-activities/week10.html
+++ b/sections/support-activities/week10.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 19 &amp; 20:</strong> Final Adjustments, Submission, and Reflection</summary>
     <article>
       <h4>Week 19: Project Completion and Workshop Maintenance</h4>

--- a/sections/support-activities/week2.html
+++ b/sections/support-activities/week2.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 3 &amp; 4:</strong> Timber Preparation, Mortising, and Joinery</summary>
     <article>
       <h4>Week 3: Dressing Timber (DAR and FEWTEL)</h4>

--- a/sections/support-activities/week3.html
+++ b/sections/support-activities/week3.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 5 &amp; 6:</strong> Bandsaw Operation, Mortise and Tenon Refinement</summary>
     <article>
       <h4>Week 5: Bandsaw Safety and Mortise and Tenon Accuracy</h4>

--- a/sections/support-activities/week4.html
+++ b/sections/support-activities/week4.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 7 &amp; 8:</strong> Timber Thicknessing, Orthogonal Drawings, Dry Clamping, and WMS</summary>
     <article>
       <h4>Week 7: Thicknesser SOP and Orthogonal Drawings</h4>

--- a/sections/support-activities/week5.html
+++ b/sections/support-activities/week5.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 9 &amp; 10:</strong> Design Features and Advanced Orthogonal Drawings</summary>
     <article>
       <h4>Week 9: Adding Design Features and Orthogonal Drawings</h4>

--- a/sections/support-activities/week6.html
+++ b/sections/support-activities/week6.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 11 &amp; 12:</strong> Assembly, Gluing, Sequencing, and Time Planning</summary>
     <article>
       <h4>Week 11: Assembly, Gluing Techniques, and Costing</h4>

--- a/sections/support-activities/week7.html
+++ b/sections/support-activities/week7.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 13 &amp; 14:</strong> Finishing Techniques, Timber Sustainability, and Industry Preparation</summary>
     <article>
       <h4>Week 13: Timber Finishing and Sustainable Practices</h4>

--- a/sections/support-activities/week8.html
+++ b/sections/support-activities/week8.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 15 &amp; 16:</strong> Chemical Safety, Polishing, and Environmental Responsibility</summary>
     <article>
       <h4>Week 15: Chemical Handling and Material Safety Data Sheets (MSDS)</h4>

--- a/sections/support-activities/week9.html
+++ b/sections/support-activities/week9.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 17 &amp; 18:</strong> Portfolio Presentation, Project Evaluation, and Comprehensive Review</summary>
     <article>
       <h4>Week 17: Portfolio Presentation and Project Evaluation</h4>

--- a/support theory content/week1.html
+++ b/support theory content/week1.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 1 &amp; 2:</strong> Introduction to Workshop Safety, Marking, and Measuring</summary>
     <article>
       <h4>Week 1: Workshop Safety and Basic Procedures</h4>

--- a/support theory content/week10.html
+++ b/support theory content/week10.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 19 &amp; 20:</strong> Final Adjustments, Submission, and Reflection</summary>
     <article>
       <h4>Week 19: Project Completion and Workshop Maintenance</h4>

--- a/support theory content/week2.html
+++ b/support theory content/week2.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 3 &amp; 4:</strong> Timber Preparation, Mortising, and Joinery</summary>
     <article>
       <h4>Week 3: Dressing Timber (DAR and FEWTEL)</h4>

--- a/support theory content/week3.html
+++ b/support theory content/week3.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 5 &amp; 6:</strong> Bandsaw Operation, Mortise and Tenon Refinement</summary>
     <article>
       <h4>Week 5: Bandsaw Safety and Mortise and Tenon Accuracy</h4>

--- a/support theory content/week4.html
+++ b/support theory content/week4.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 7 &amp; 8:</strong> Timber Thicknessing, Orthogonal Drawings, Dry Clamping, and WMS</summary>
     <article>
       <h4>Week 7: Thicknesser SOP and Orthogonal Drawings</h4>

--- a/support theory content/week5.html
+++ b/support theory content/week5.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 9 &amp; 10:</strong> Design Features and Advanced Orthogonal Drawings</summary>
     <article>
       <h4>Week 9: Adding Design Features and Orthogonal Drawings</h4>

--- a/support theory content/week6.html
+++ b/support theory content/week6.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 11 &amp; 12:</strong> Assembly, Gluing, Sequencing, and Time Planning</summary>
     <article>
       <h4>Week 11: Assembly, Gluing Techniques, and Costing</h4>

--- a/support theory content/week7.html
+++ b/support theory content/week7.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 13 &amp; 14:</strong> Finishing Techniques, Timber Sustainability, and Industry Preparation</summary>
     <article>
       <h4>Week 13: Timber Finishing and Sustainable Practices</h4>

--- a/support theory content/week8.html
+++ b/support theory content/week8.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 15 &amp; 16:</strong> Chemical Safety, Polishing, and Environmental Responsibility</summary>
     <article>
       <h4>Week 15: Chemical Handling and Material Safety Data Sheets (MSDS)</h4>

--- a/support theory content/week9.html
+++ b/support theory content/week9.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details>
+<details open>
     <summary><strong>Weeks 17 &amp; 18:</strong> Portfolio Presentation, Project Evaluation, and Comprehensive Review</summary>
     <article>
       <h4>Week 17: Portfolio Presentation and Project Evaluation</h4>


### PR DESCRIPTION
## Summary
- expand all weekly lesson content by default so it appears immediately when a week page is opened

## Testing
- `grep -R "<details open>" -n | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_68806136d9e8832683cdc775b0413878