### PR TITLE
Collapse weekly sections by default

### DIFF
--- a/sections/advanced-activities/week1.html
+++ b/sections/advanced-activities/week1.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
     <summary><strong>Weeks 1 &amp; 2:</strong> Introduction, Workshop Safety, Design Sketches, and Timber Mark-out</summary>
     <form class="quiz" id="adv-week1-form">
       <ol>

--- a/sections/advanced-activities/week10.html
+++ b/sections/advanced-activities/week10.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
     <summary><strong>Weeks 19 &amp; 20:</strong> Final Adjustments, Submission, and Reflective Practice</summary>
     <form class="quiz" id="adv-week19-form">
       <ol>

--- a/sections/advanced-activities/week2.html
+++ b/sections/advanced-activities/week2.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
     <summary><strong>Weeks 3 &amp; 4:</strong> Timber Dressing, Mortising, and Joinery</summary>
     <form class="quiz" id="adv-week3-form">
       <ol>

--- a/sections/advanced-activities/week3.html
+++ b/sections/advanced-activities/week3.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
     <summary><strong>Weeks 5 &amp; 6:</strong> Bandsaw Operation, Mortise and Tenon Refinement</summary>
     <form class="quiz" id="adv-week5-form">
       <ol>

--- a/sections/advanced-activities/week4.html
+++ b/sections/advanced-activities/week4.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
     <summary><strong>Weeks 7 &amp; 8:</strong> Timber Thicknessing, Orthogonal Drawings, Dry Clamping, and WMS</summary>
     <form class="quiz" id="adv-week7-form">
       <ol>

--- a/sections/advanced-activities/week5.html
+++ b/sections/advanced-activities/week5.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
     <summary><strong>Weeks 9 &amp; 10:</strong> Design Features, Advanced Orthogonal Drawings, and CAD</summary>
     <form class="quiz" id="adv-week9-form">
       <ol>

--- a/sections/advanced-activities/week6.html
+++ b/sections/advanced-activities/week6.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
     <summary><strong>Weeks 11 &amp; 12:</strong> Assembly, Gluing Techniques, Sequencing, and Time Planning</summary>
     <form class="quiz" id="adv-week11-form">
       <ol>

--- a/sections/advanced-activities/week7.html
+++ b/sections/advanced-activities/week7.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
     <summary><strong>Weeks 13 &amp; 14:</strong> Finishing Techniques, Timber Sustainability, and Industry Preparation</summary>
     <form class="quiz" id="adv-week13-form">
       <ol>

--- a/sections/advanced-activities/week8.html
+++ b/sections/advanced-activities/week8.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
     <summary><strong>Weeks 15 &amp; 16:</strong> Chemical Safety, Polishing, Sustainability, and Environmental Responsibility</summary>
     <form class="quiz" id="adv-week15-form">
       <ol>

--- a/sections/advanced-activities/week9.html
+++ b/sections/advanced-activities/week9.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
     <summary><strong>Weeks 17 &amp; 18:</strong> Portfolio Presentation, Project Evaluation, and Comprehensive Review</summary>
     <form class="quiz" id="adv-week17-form">
       <ol>

--- a/sections/main-theory/week1.html
+++ b/sections/main-theory/week1.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
       <summary><strong>Week 1:</strong> Introduction, OHS, and Risk Management</summary>
       <article>
         <h4>Overview</h4>

--- a/sections/main-theory/week10.html
+++ b/sections/main-theory/week10.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
         <summary><strong>Week 10:</strong> Advanced Design Features and Orthogonal Drawings</summary>
         <article>
           <h4>Theory Content</h4>

--- a/sections/main-theory/week11.html
+++ b/sections/main-theory/week11.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
         <summary><strong>Week 11:</strong> Assembly, Gluing Techniques, and Costing</summary>
         <article>
           <h4>Theory Content</h4>

--- a/sections/main-theory/week12.html
+++ b/sections/main-theory/week12.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
         <summary><strong>Week 12:</strong> Assembly, Gluing, Sequencing, and Time Planning</summary>
         <article>
           <h4>Theory Content</h4>

--- a/sections/main-theory/week13.html
+++ b/sections/main-theory/week13.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
         <summary><strong>Week 13:</strong> Finishing Techniques and Timber Logging</summary>
         <article>
           <h4>Theory Content</h4>

--- a/sections/main-theory/week14.html
+++ b/sections/main-theory/week14.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
         <summary><strong>Week 14:</strong> Advanced Finishing Techniques and Industry Visit Preparation</summary>
         <article>
           <h4>Theory Content</h4>

--- a/sections/main-theory/week15.html
+++ b/sections/main-theory/week15.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
         <summary><strong>Week 15:</strong> Safe Handling of Chemicals and Material Safety Data Sheets (MSDS)</summary>
         <article>
           <h4>Theory Content</h4>

--- a/sections/main-theory/week16.html
+++ b/sections/main-theory/week16.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
           <summary><strong>Week 16:</strong> Polishing Techniques, Sustainability, and Environmental Impact</summary>
           <article>
             <h4>Theory Content</h4>

--- a/sections/main-theory/week17.html
+++ b/sections/main-theory/week17.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
           <summary><strong>Week 17:</strong> Portfolio Presentation and Project Evaluation</summary>
           <article>
             <h4>Theory Content</h4>

--- a/sections/main-theory/week18.html
+++ b/sections/main-theory/week18.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
           <summary><strong>Week 18:</strong> Class Test and Review of Key Concepts</summary>
           <article>
             <h4>Theory Content</h4>

--- a/sections/main-theory/week19.html
+++ b/sections/main-theory/week19.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
   <summary><strong>Week 19:</strong> Catch-Up, Final Adjustments, and Workshop Maintenance</summary>
   <article>
     <h4>Theory Content</h4>

--- a/sections/main-theory/week2.html
+++ b/sections/main-theory/week2.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
   <summary><strong>Week 2:</strong> Design, Sketches, Measuring, and Mark-Out</summary>
   <article>
     <h4>Overview</h4>

--- a/sections/main-theory/week20.html
+++ b/sections/main-theory/week20.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
   <summary><strong>Week 20:</strong> Final Submission and Workshop Reflection</summary>
   <article>
     <h4>Theory Content</h4>

--- a/sections/main-theory/week3.html
+++ b/sections/main-theory/week3.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
       <summary><strong>Week 3:</strong> Dressing and Preparing Timber - DAR and FEWTEL</summary>
       <article>
         <h4>Theory Content</h4>

--- a/sections/main-theory/week4.html
+++ b/sections/main-theory/week4.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
       <summary><strong>Week 4:</strong> On-Guard Mortiser and Joinery Techniques</summary>
       <article>
         <h4>Theory Content</h4>

--- a/sections/main-theory/week5.html
+++ b/sections/main-theory/week5.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
       <summary><strong>Week 5:</strong> Mortise and Tenon Joints &amp; Bandsaw Safety</summary>
       <article>
         <h4>Theory Content</h4>

--- a/sections/main-theory/week6.html
+++ b/sections/main-theory/week6.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
         <summary><strong>Week 6:</strong> Bandsaw SOP and Refinement of Mortise and Tenon Joints</summary>
         <article>
           <h4>Theory Content</h4>

--- a/sections/main-theory/week7.html
+++ b/sections/main-theory/week7.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
         <summary><strong>Week 7:</strong> Bandsaw SOP and Refinement of Mortise and Tenon Joints</summary>
         <article>
           <h4>Theory Content</h4>

--- a/sections/main-theory/week8.html
+++ b/sections/main-theory/week8.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
         <summary><strong>Week 8:</strong> Dry Clamping, Work Method Statements (WMS), and SOPs</summary>
         <article>
           <h4>Theory Content</h4>

--- a/sections/main-theory/week9.html
+++ b/sections/main-theory/week9.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
         <summary><strong>Week 9:</strong> Adding Design Features and Orthogonal Drawings</summary>
         <article>
           <h4>Theory Content</h4>

--- a/sections/support-activities/week1.html
+++ b/sections/support-activities/week1.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
     <summary><strong>Weeks 1 &amp; 2:</strong> Introduction to Workshop Safety, Marking, and Measuring</summary>
     <article>
       <h4>Week 1: Workshop Safety and Basic Procedures</h4>

--- a/sections/support-activities/week10.html
+++ b/sections/support-activities/week10.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
     <summary><strong>Weeks 19 &amp; 20:</strong> Final Adjustments, Submission, and Reflection</summary>
     <article>
       <h4>Week 19: Project Completion and Workshop Maintenance</h4>

--- a/sections/support-activities/week2.html
+++ b/sections/support-activities/week2.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
     <summary><strong>Weeks 3 &amp; 4:</strong> Timber Preparation, Mortising, and Joinery</summary>
     <article>
       <h4>Week 3: Dressing Timber (DAR and FEWTEL)</h4>

--- a/sections/support-activities/week3.html
+++ b/sections/support-activities/week3.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
     <summary><strong>Weeks 5 &amp; 6:</strong> Bandsaw Operation, Mortise and Tenon Refinement</summary>
     <article>
       <h4>Week 5: Bandsaw Safety and Mortise and Tenon Accuracy</h4>

--- a/sections/support-activities/week4.html
+++ b/sections/support-activities/week4.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
     <summary><strong>Weeks 7 &amp; 8:</strong> Timber Thicknessing, Orthogonal Drawings, Dry Clamping, and WMS</summary>
     <article>
       <h4>Week 7: Thicknesser SOP and Orthogonal Drawings</h4>

--- a/sections/support-activities/week5.html
+++ b/sections/support-activities/week5.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
     <summary><strong>Weeks 9 &amp; 10:</strong> Design Features and Advanced Orthogonal Drawings</summary>
     <article>
       <h4>Week 9: Adding Design Features and Orthogonal Drawings</h4>

--- a/sections/support-activities/week6.html
+++ b/sections/support-activities/week6.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
     <summary><strong>Weeks 11 &amp; 12:</strong> Assembly, Gluing, Sequencing, and Time Planning</summary>
     <article>
       <h4>Week 11: Assembly, Gluing Techniques, and Costing</h4>

--- a/sections/support-activities/week7.html
+++ b/sections/support-activities/week7.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
     <summary><strong>Weeks 13 &amp; 14:</strong> Finishing Techniques, Timber Sustainability, and Industry Preparation</summary>
     <article>
       <h4>Week 13: Timber Finishing and Sustainable Practices</h4>

--- a/sections/support-activities/week8.html
+++ b/sections/support-activities/week8.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
     <summary><strong>Weeks 15 &amp; 16:</strong> Chemical Safety, Polishing, and Environmental Responsibility</summary>
     <article>
       <h4>Week 15: Chemical Handling and Material Safety Data Sheets (MSDS)</h4>

--- a/sections/support-activities/week9.html
+++ b/sections/support-activities/week9.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body>
-<details open>
+<details>
     <summary><strong>Weeks 17 &amp; 18:</strong> Portfolio Presentation, Project Evaluation, and Comprehensive Review</summary>
     <article>
       <h4>Week 17: Portfolio Presentation and Project Evaluation</h4>


### PR DESCRIPTION
## Summary
- keep all weekly `<details>` collapsed when pages load

## Testing
- `grep -R "<details open" -n sections | head`

------
https://chatgpt.com/codex/tasks/task_e_6882f36e77308326a0cd6d7f52ed27f3