### PR TITLE
Fix open sections

### DIFF
--- a/Main theory Content/week1.html
+++ b/Main theory Content/week1.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
       <summary><strong>Week 1:</strong> Introduction, OHS, and Risk Management</summary>
       <article>
         <h4>Overview</h4>

--- a/Main theory Content/week10.html
+++ b/Main theory Content/week10.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
         <summary><strong>Week 10:</strong> Advanced Design Features and Orthogonal Drawings</summary>
         <article>
           <h4>Theory Content</h4>

--- a/Main theory Content/week11.html
+++ b/Main theory Content/week11.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
         <summary><strong>Week 11:</strong> Assembly, Gluing Techniques, and Costing</summary>
         <article>
           <h4>Theory Content</h4>

--- a/Main theory Content/week12.html
+++ b/Main theory Content/week12.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
         <summary><strong>Week 12:</strong> Assembly, Gluing, Sequencing, and Time Planning</summary>
         <article>
           <h4>Theory Content</h4>

--- a/Main theory Content/week13.html
+++ b/Main theory Content/week13.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
         <summary><strong>Week 13:</strong> Finishing Techniques and Timber Logging</summary>
         <article>
           <h4>Theory Content</h4>

--- a/Main theory Content/week14.html
+++ b/Main theory Content/week14.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
         <summary><strong>Week 14:</strong> Advanced Finishing Techniques and Industry Visit Preparation</summary>
         <article>
           <h4>Theory Content</h4>

--- a/Main theory Content/week15.html
+++ b/Main theory Content/week15.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
         <summary><strong>Week 15:</strong> Safe Handling of Chemicals and Material Safety Data Sheets (MSDS)</summary>
         <article>
           <h4>Theory Content</h4>

--- a/Main theory Content/week16.html
+++ b/Main theory Content/week16.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
           <summary><strong>Week 16:</strong> Polishing Techniques, Sustainability, and Environmental Impact</summary>
           <article>
             <h4>Theory Content</h4>

--- a/Main theory Content/week17.html
+++ b/Main theory Content/week17.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
           <summary><strong>Week 17:</strong> Portfolio Presentation and Project Evaluation</summary>
           <article>
             <h4>Theory Content</h4>

--- a/Main theory Content/week18.html
+++ b/Main theory Content/week18.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
           <summary><strong>Week 18:</strong> Class Test and Review of Key Concepts</summary>
           <article>
             <h4>Theory Content</h4>

--- a/Main theory Content/week19.html
+++ b/Main theory Content/week19.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
   <summary><strong>Week 19:</strong> Catch-Up, Final Adjustments, and Workshop Maintenance</summary>
   <article>
     <h4>Theory Content</h4>

--- a/Main theory Content/week2.html
+++ b/Main theory Content/week2.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
   <summary><strong>Week 2:</strong> Design, Sketches, Measuring, and Mark-Out</summary>
   <article>
     <h4>Overview</h4>

--- a/Main theory Content/week20.html
+++ b/Main theory Content/week20.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
   <summary><strong>Week 20:</strong> Final Submission and Workshop Reflection</summary>
   <article>
     <h4>Theory Content</h4>

--- a/Main theory Content/week3.html
+++ b/Main theory Content/week3.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
       <summary><strong>Week 3:</strong> Dressing and Preparing Timber - DAR and FEWTEL</summary>
       <article>
         <h4>Theory Content</h4>

--- a/Main theory Content/week4.html
+++ b/Main theory Content/week4.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
       <summary><strong>Week 4:</strong> On-Guard Mortiser and Joinery Techniques</summary>
       <article>
         <h4>Theory Content</h4>

--- a/Main theory Content/week5.html
+++ b/Main theory Content/week5.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
       <summary><strong>Week 5:</strong> Mortise and Tenon Joints &amp; Bandsaw Safety</summary>
       <article>
         <h4>Theory Content</h4>

--- a/Main theory Content/week6.html
+++ b/Main theory Content/week6.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
         <summary><strong>Week 6:</strong> Bandsaw SOP and Refinement of Mortise and Tenon Joints</summary>
         <article>
           <h4>Theory Content</h4>

--- a/Main theory Content/week7.html
+++ b/Main theory Content/week7.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
         <summary><strong>Week 7:</strong> Bandsaw SOP and Refinement of Mortise and Tenon Joints</summary>
         <article>
           <h4>Theory Content</h4>

--- a/Main theory Content/week8.html
+++ b/Main theory Content/week8.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
         <summary><strong>Week 8:</strong> Dry Clamping, Work Method Statements (WMS), and SOPs</summary>
         <article>
           <h4>Theory Content</h4>

--- a/Main theory Content/week9.html
+++ b/Main theory Content/week9.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
         <summary><strong>Week 9:</strong> Adding Design Features and Orthogonal Drawings</summary>
         <article>
           <h4>Theory Content</h4>

--- a/advanced theory content/week1.html
+++ b/advanced theory content/week1.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
     <summary><strong>Weeks 1 &amp; 2:</strong> Introduction, Workshop Safety, Design Sketches, and Timber Mark-out</summary>
     <form class="quiz" id="adv-week1-form">
       <ol>

--- a/advanced theory content/week10.html
+++ b/advanced theory content/week10.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
     <summary><strong>Weeks 19 &amp; 20:</strong> Final Adjustments, Submission, and Reflective Practice</summary>
     <form class="quiz" id="adv-week19-form">
       <ol>

--- a/advanced theory content/week2.html
+++ b/advanced theory content/week2.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
     <summary><strong>Weeks 3 &amp; 4:</strong> Timber Dressing, Mortising, and Joinery</summary>
     <form class="quiz" id="adv-week3-form">
       <ol>

--- a/advanced theory content/week3.html
+++ b/advanced theory content/week3.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
     <summary><strong>Weeks 5 &amp; 6:</strong> Bandsaw Operation, Mortise and Tenon Refinement</summary>
     <form class="quiz" id="adv-week5-form">
       <ol>

--- a/advanced theory content/week4.html
+++ b/advanced theory content/week4.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
     <summary><strong>Weeks 7 &amp; 8:</strong> Timber Thicknessing, Orthogonal Drawings, Dry Clamping, and WMS</summary>
     <form class="quiz" id="adv-week7-form">
       <ol>

--- a/advanced theory content/week5.html
+++ b/advanced theory content/week5.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
     <summary><strong>Weeks 9 &amp; 10:</strong> Design Features, Advanced Orthogonal Drawings, and CAD</summary>
     <form class="quiz" id="adv-week9-form">
       <ol>

--- a/advanced theory content/week6.html
+++ b/advanced theory content/week6.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
     <summary><strong>Weeks 11 &amp; 12:</strong> Assembly, Gluing Techniques, Sequencing, and Time Planning</summary>
     <form class="quiz" id="adv-week11-form">
       <ol>

--- a/advanced theory content/week7.html
+++ b/advanced theory content/week7.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
     <summary><strong>Weeks 13 &amp; 14:</strong> Finishing Techniques, Timber Sustainability, and Industry Preparation</summary>
     <form class="quiz" id="adv-week13-form">
       <ol>

--- a/advanced theory content/week8.html
+++ b/advanced theory content/week8.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
     <summary><strong>Weeks 15 &amp; 16:</strong> Chemical Safety, Polishing, Sustainability, and Environmental Responsibility</summary>
     <form class="quiz" id="adv-week15-form">
       <ol>

--- a/advanced theory content/week9.html
+++ b/advanced theory content/week9.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
     <summary><strong>Weeks 17 &amp; 18:</strong> Portfolio Presentation, Project Evaluation, and Comprehensive Review</summary>
     <form class="quiz" id="adv-week17-form">
       <ol>

--- a/support theory content/week1.html
+++ b/support theory content/week1.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
     <summary><strong>Weeks 1 &amp; 2:</strong> Introduction to Workshop Safety, Marking, and Measuring</summary>
     <article>
       <h4>Week 1: Workshop Safety and Basic Procedures</h4>

--- a/support theory content/week10.html
+++ b/support theory content/week10.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
     <summary><strong>Weeks 19 &amp; 20:</strong> Final Adjustments, Submission, and Reflection</summary>
     <article>
       <h4>Week 19: Project Completion and Workshop Maintenance</h4>

--- a/support theory content/week2.html
+++ b/support theory content/week2.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
     <summary><strong>Weeks 3 &amp; 4:</strong> Timber Preparation, Mortising, and Joinery</summary>
     <article>
       <h4>Week 3: Dressing Timber (DAR and FEWTEL)</h4>

--- a/support theory content/week3.html
+++ b/support theory content/week3.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
     <summary><strong>Weeks 5 &amp; 6:</strong> Bandsaw Operation, Mortise and Tenon Refinement</summary>
     <article>
       <h4>Week 5: Bandsaw Safety and Mortise and Tenon Accuracy</h4>

--- a/support theory content/week4.html
+++ b/support theory content/week4.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
     <summary><strong>Weeks 7 &amp; 8:</strong> Timber Thicknessing, Orthogonal Drawings, Dry Clamping, and WMS</summary>
     <article>
       <h4>Week 7: Thicknesser SOP and Orthogonal Drawings</h4>

--- a/support theory content/week5.html
+++ b/support theory content/week5.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
     <summary><strong>Weeks 9 &amp; 10:</strong> Design Features and Advanced Orthogonal Drawings</summary>
     <article>
       <h4>Week 9: Adding Design Features and Orthogonal Drawings</h4>

--- a/support theory content/week6.html
+++ b/support theory content/week6.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
     <summary><strong>Weeks 11 &amp; 12:</strong> Assembly, Gluing, Sequencing, and Time Planning</summary>
     <article>
       <h4>Week 11: Assembly, Gluing Techniques, and Costing</h4>

--- a/support theory content/week7.html
+++ b/support theory content/week7.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
     <summary><strong>Weeks 13 &amp; 14:</strong> Finishing Techniques, Timber Sustainability, and Industry Preparation</summary>
     <article>
       <h4>Week 13: Timber Finishing and Sustainable Practices</h4>

--- a/support theory content/week8.html
+++ b/support theory content/week8.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
     <summary><strong>Weeks 15 &amp; 16:</strong> Chemical Safety, Polishing, and Environmental Responsibility</summary>
     <article>
       <h4>Week 15: Chemical Handling and Material Safety Data Sheets (MSDS)</h4>

--- a/support theory content/week9.html
+++ b/support theory content/week9.html
@@ -300,7 +300,7 @@ summary { font-weight: bold; }
 <main class="content">
 
 <main class="content">
-<details open>
+<details>
     <summary><strong>Weeks 17 &amp; 18:</strong> Portfolio Presentation, Project Evaluation, and Comprehensive Review</summary>
     <article>
       <h4>Week 17: Portfolio Presentation and Project Evaluation</h4>


### PR DESCRIPTION
## Summary
- collapse week content in root directories by removing `open` attribute

## Testing
- `grep -R "<details open" 'Main theory Content' 'support theory content' 'advanced theory content'`

------
https://chatgpt.com/codex/tasks/task_e_6882f4e0f0608326ae63815382e59594